### PR TITLE
Get to 90% complete

### DIFF
--- a/auth-service.tf
+++ b/auth-service.tf
@@ -89,6 +89,26 @@ locals {
       ]
     },
     {
+      clientId    = "static/taskcluster/gce-provider"
+      accessToken = "${random_string.gce_provider_access_token.result}"
+      description = "..."
+
+      scopes = [
+        "queue:claim-work:gce-provider/*",
+        "assume:worker-id:*",
+        "assume:worker-type:gce-provider/*",
+        "queue:worker-id:gce-worker-test/*",                          // TODO: Probably not right
+        "auth:create-client:worker/gce/taskcluster-staging-214020/*", // TODO: configure
+      ]
+    },
+    {
+      clientId    = "static/taskcluster/events"
+      accessToken = "${random_string.events_access_token.result}"
+      description = "..."
+
+      scopes = []
+    },
+    {
       clientId    = "static/taskcluster/queue"
       accessToken = "${random_string.queue_access_token.result}"
       description = "..."
@@ -158,19 +178,6 @@ module "auth_web_service" {
   root_url          = "${var.root_url}"
   secret_keys       = "${module.auth_secrets.env_var_keys}"
   docker_image      = "${local.taskcluster_image_auth}"
-}
-
-module "auth_expire_sentry" {
-  source           = "modules/scheduled-job"
-  project_name     = "taskcluster-auth"
-  job_name         = "expireSentry"
-  schedule         = "0 0 * * *"
-  deadline_seconds = 86400
-  secret_name      = "${module.auth_secrets.secret_name}"
-  secrets_hash     = "${module.auth_secrets.secrets_hash}"
-  root_url         = "${var.root_url}"
-  secret_keys      = "${module.auth_secrets.env_var_keys}"
-  docker_image     = "${local.taskcluster_image_auth}"
 }
 
 module "auth_purge_expired_clients" {

--- a/events-service.tf
+++ b/events-service.tf
@@ -1,0 +1,44 @@
+module "events_rabbitmq_user" {
+  source         = "modules/rabbitmq-user"
+  project_name   = "taskcluster-events"
+  rabbitmq_vhost = "${var.rabbitmq_vhost}"
+}
+
+resource "random_string" "events_access_token" {
+  length           = 65
+  override_special = "_-"
+}
+
+module "events_secrets" {
+  source            = "modules/service-secrets"
+  project_name      = "taskcluster-events"
+  disabled_services = "${var.disabled_services}"
+
+  secrets = {
+    TASKCLUSTER_CLIENT_ID    = "static/taskcluster/events"
+    TASKCLUSTER_ACCESS_TOKEN = "${random_string.events_access_token.result}"
+    DEBUG                    = "*"
+    NODE_ENV                 = "production"
+    MONITORING_ENABLE        = "false"
+    PUBLISH_METADATA         = "false"
+    PULSE_USERNAME           = "taskcluster-events"
+    PULSE_PASSWORD           = "${module.events_rabbitmq_user.password}"
+    PULSE_HOSTNAME           = "${var.rabbitmq_hostname}"
+    PULSE_VHOST              = "${var.rabbitmq_vhost}"
+    FORCE_SSL                = "false"
+    TRUST_PROXY              = "true"
+  }
+}
+
+module "events_web_service" {
+  source         = "modules/deployment"
+  project_name   = "taskcluster-events"
+  service_name   = "events"
+  proc_name      = "web"
+  readiness_path = "/api/events/v1/ping"
+  secret_name    = "${module.events_secrets.secret_name}"
+  secrets_hash   = "${module.events_secrets.secrets_hash}"
+  root_url       = "${var.root_url}"
+  secret_keys    = "${module.events_secrets.env_var_keys}"
+  docker_image   = "${local.taskcluster_image_events}"
+}

--- a/gce-provider-service.tf
+++ b/gce-provider-service.tf
@@ -1,0 +1,117 @@
+resource "random_string" "gce_provider_access_token" {
+  length           = 65
+  override_special = "_-"
+}
+
+resource "google_service_account" "gce_provider" {
+  account_id   = "taskcluster-gce-provider"                 // TODO: name includes cluster name to allow for 2 tc in one project
+  display_name = "Taskcluster GCE Provider Service Account"
+}
+
+resource "google_service_account_key" "gce_provider" {
+  service_account_id = "${google_service_account.gce_provider.name}"
+}
+
+// TODO: Make a custom role and lock down to just the permissions necessary
+//       Also it would make sense to put the workers in another project
+resource "google_project_iam_member" "gce_provider_compute_images" {
+  member = "serviceAccount:${google_service_account.gce_provider.email}"
+  role   = "roles/compute.imageUser"
+}
+
+resource "google_project_iam_member" "gce_provider_compute_instances" {
+  member = "serviceAccount:${google_service_account.gce_provider.email}"
+  role   = "roles/compute.instanceAdmin.v1"
+}
+
+resource "google_project_iam_member" "gce_provider_iam" {
+  member = "serviceAccount:${google_service_account.gce_provider.email}"
+  role   = "roles/iam.serviceAccountAdmin"
+}
+
+resource "google_project_iam_member" "gce_provider_roles" {
+  member = "serviceAccount:${google_service_account.gce_provider.email}"
+  role   = "roles/iam.roleAdmin"
+}
+
+resource "google_project_iam_member" "gce_provider_policy" {
+  member = "serviceAccount:${google_service_account.gce_provider.email}"
+  role   = "roles/resourcemanager.projectIamAdmin"
+}
+
+resource "google_project_iam_member" "gce_provider_assign" {
+  member = "serviceAccount:${google_service_account.gce_provider.email}"
+  role   = "roles/iam.serviceAccountUser"
+}
+
+locals {
+  gce_worker_types = "[{\"configMap\":{\"authBaseUrl\":\"https://taskcluster.imbstack.com/api/auth/v1\",\"cachesDir\":\"/home/taskcluster/caches\",\"disableReboots\":true,\"livelogSecret\":\"foobar\",\"queueBaseUrl\":\"https://taskcluster.imbstack.com/api/queue/v1\",\"shutdownMachineOnIdle\":false,\"shutdownMachineOnInternalError\":false,\"signingKeyLocation\":\"/home/taskcluster/signing.key\",\"tasksDir\":\"/home/taskcluster\"},\"diskSizeGb\":32,\"image\":\"taskcluster-generic-worker-debian-9-1535097042\",\"instances\":2,\"name\":\"gce-worker-test\",\"version\":1,\"workerGroup\":\"gce-worker-test\",\"zones\":[\"us-east1-b\"]}]"
+}
+
+module "gce_provider_secrets" {
+  source            = "modules/service-secrets"
+  project_name      = "gce-provider"
+  disabled_services = "${var.disabled_services}"
+
+  secrets = {
+    TASKCLUSTER_CLIENT_ID    = "static/taskcluster/gce-provider"
+    TASKCLUSTER_ACCESS_TOKEN = "${random_string.gce_provider_access_token.result}"
+    DEBUG                    = "*"
+    NODE_ENV                 = "production"
+    MONITORING_ENABLE        = "false"
+    PUBLISH_METADATA         = "false"
+    FORCE_SSL                = "false"
+    TRUST_PROXY              = "true"
+    WORKER_TYPES             = "{}"
+    PROVISIONER_ID           = "gce-provider"
+
+    // TODO: configurable
+    GOOGLE_PROJECT = "taskcluster-staging-214020"
+
+    // TODO: Unnecessary once worker has rootUrl support
+    CREDENTIAL_URL = "https://taskcluster.imbstack.com/api/gce-provider/v1/credentials"
+
+    // TODO: configurable
+    AUDIENCE                       = "taskclusteraudience"
+    GOOGLE_APPLICATION_CREDENTIALS = "/var/run/secret/cloud.google.com/service-account.json"
+    WORKER_TYPES                   = "${local.gce_worker_types}"
+  }
+
+  secret_files = {
+    service-account-key = "${base64decode(google_service_account_key.gce_provider.private_key)}"
+  }
+}
+
+module "gce_provider_web_service" {
+  source         = "modules/deployment"
+  project_name   = "gce-provider"
+  service_name   = "gce-provider"
+  proc_name      = "web"
+  readiness_path = "/api/gce-provider/v1/ping"
+  secret_name    = "${module.gce_provider_secrets.secret_name}"
+  secrets_hash   = "${module.gce_provider_secrets.secrets_hash}"
+  root_url       = "${var.root_url}"
+  secret_keys    = "${module.gce_provider_secrets.env_var_keys}"
+  docker_image   = "${local.taskcluster_image_gce-provider}"
+}
+
+module "gce_provider_create_workers" {
+  source           = "modules/scheduled-job"
+  project_name     = "gce-provider"
+  job_name         = "createTypes"
+  schedule         = "*/5 * * * *"
+  deadline_seconds = 300
+  secret_name      = "${module.gce_provider_secrets.secret_name}"
+  secrets_hash     = "${module.gce_provider_secrets.secrets_hash}"
+  root_url         = "${var.root_url}"
+  secret_keys      = "${module.gce_provider_secrets.env_var_keys}"
+  docker_image     = "${local.taskcluster_image_gce-provider}"
+
+  volume_mounts = [
+    {
+      source = "service-account-key"
+      name   = "service-account.json"
+      path   = "/var/run/secret/cloud.google.com/"
+    },
+  ]
+}

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -31,6 +31,8 @@ spec:
             - {service_name: queue, project_name: taskcluster-queue}
             - {service_name: hooks, project_name: taskcluster-hooks}
             - {service_name: index, project_name: taskcluster-index}
+            - {service_name: gce-provider, project_name: gce-provider}
+            - {service_name: events, project_name: taskcluster-events}
           each(svc):
             $if: '!(svc.project_name in disabled_services)'
             then:

--- a/modules/deployment/deployment.yaml
+++ b/modules/deployment/deployment.yaml
@@ -28,6 +28,17 @@ in:
             else: 'static'
       spec:
         serviceAccountName: ${project_name}
+        volumes:
+          $if: 'len(volume_mounts) > 0'
+          then:
+            $map: {$eval: volume_mounts}
+            each(mount):
+              name: ${mount.source}
+              secret:
+                secretName: ${secret_name}
+                items:
+                  - key: ${mount.source}
+                    path: ${mount.name}
         containers:
         - name: ${project_name}
           image: ${docker_image}
@@ -54,6 +65,14 @@ in:
                     secretKeyRef:
                       name: '${secret_name}'
                       key: '${k}'
+          volumeMounts:
+            $if: 'len(volume_mounts) > 0'
+            then:
+              $map: {$eval: volume_mounts}
+              each(mount):
+                name: ${mount.source}
+                mountPath: ${mount.path}
+                readOnly: true
           ports:
           - $if: 'background_job == "0"'
             then:

--- a/modules/deployment/main.tf
+++ b/modules/deployment/main.tf
@@ -13,6 +13,7 @@ locals {
     memory         = "${var.memory}"
     replicas       = "${var.replicas}"
     background_job = "${var.background_job}"
+    volume_mounts  = "${var.volume_mounts}"
   }
 
   is_enabled = "${contains(var.disabled_services, var.project_name) ? 0 : 1}"

--- a/modules/deployment/variables.tf
+++ b/modules/deployment/variables.tf
@@ -32,7 +32,13 @@ variable "secret_name" {
 
 variable "secrets_hash" {
   type        = "string"
-  description = "Used to know if the deployment needs to be updated"
+  description = "Used to know if the deployment needs to be updated."
+}
+
+variable "volume_mounts" {
+  type        = "list"
+  default     = []
+  description = "A set of fields from the secrets to mount as files."
 }
 
 variable "disabled_services" {

--- a/modules/scheduled-job/cron.yaml
+++ b/modules/scheduled-job/cron.yaml
@@ -14,6 +14,17 @@ spec:
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: {$eval: number(deadline_seconds)}
+          volumes:
+            $if: 'len(volume_mounts) > 0'
+            then:
+              $map: {$eval: volume_mounts}
+              each(mount):
+                name: ${mount.source}
+                secret:
+                  secretName: ${secret_name}
+                  items:
+                    - key: ${mount.source}
+                      path: ${mount.name}
           containers:
           - name: ${project_name}-${lowercase(job_name)}
             image: ${docker_image}
@@ -24,6 +35,14 @@ spec:
               requests:
                 cpu: 100m
                 memory: 100Mi
+            volumeMounts:
+              $if: 'len(volume_mounts) > 0'
+              then:
+                $map: {$eval: volume_mounts}
+                each(mount):
+                  name: ${mount.source}
+                  mountPath: ${mount.path}
+                  readOnly: true
             env:
               $flatten:
                 - name: TASKCLUSTER_ROOT_URL

--- a/modules/scheduled-job/main.tf
+++ b/modules/scheduled-job/main.tf
@@ -9,6 +9,7 @@ locals {
     secrets_hash     = "${var.secrets_hash}"
     secret_name      = "${var.secret_name}"
     root_url         = "${var.root_url}"
+    volume_mounts    = "${var.volume_mounts}"
   }
 }
 

--- a/modules/scheduled-job/variables.tf
+++ b/modules/scheduled-job/variables.tf
@@ -44,3 +44,9 @@ variable "secret_name" {
   type        = "string"
   description = "The kubernetes secret to pull the variables from."
 }
+
+variable "volume_mounts" {
+  type        = "list"
+  default     = []
+  description = "A set of fields from the secrets to mount as files."
+}

--- a/modules/service-secrets/main.tf
+++ b/modules/service-secrets/main.tf
@@ -1,6 +1,6 @@
 locals {
   context = {
-    secrets      = "${var.secrets}"
+    secrets      = "${merge(var.secret_files, var.secrets)}"
     project_name = "${var.project_name}"
   }
 

--- a/modules/service-secrets/outputs.tf
+++ b/modules/service-secrets/outputs.tf
@@ -7,5 +7,5 @@ output "secret_name" {
 }
 
 output "secrets_hash" {
-  value = "${sha512(join("", k8s_manifest.secrets_resource.*.content))}"
+  value = "${sha512(data.jsone_template.secrets_resource.rendered)}"
 }

--- a/modules/service-secrets/variables.tf
+++ b/modules/service-secrets/variables.tf
@@ -5,7 +5,14 @@ variable "project_name" {
 
 variable "secrets" {
   type        = "map"
+  default     = {}
   description = "A map of secrets to make available to the service."
+}
+
+variable "secret_files" {
+  type        = "map"
+  default     = {}
+  description = "A map of secrets to make available to the service as files. Will _not_ be included in the set of env_var_keys that are exported."
 }
 
 variable "disabled_services" {

--- a/taskcluster.tf.json
+++ b/taskcluster.tf.json
@@ -1,17 +1,19 @@
 {
   "locals": {
-    "taskcluster_image_auth": "imbstack/taskcluster-auth:SVC-909336005686",
-    "taskcluster_image_queue": "imbstack/taskcluster-queue:SVC-45d7581ba4ab",
-    "taskcluster_image_index": "imbstack/taskcluster-index:SVC-868e322ebfa0",
-    "taskcluster_image_purge-cache": "imbstack/taskcluster-purge-cache:SVC-a4e10a043dc2",
-    "taskcluster_image_github": "imbstack/taskcluster-github:SVC-891631b5bfe8",
-    "taskcluster_image_login": "imbstack/taskcluster-login:SVC-f29024f1d381",
-    "taskcluster_image_pulse": "imbstack/taskcluster-pulse:SVC-2d1d19ff6695",
-    "taskcluster_image_hooks": "imbstack/taskcluster-hooks:SVC-52a3b8ffa9af",
-    "taskcluster_image_secrets": "imbstack/taskcluster-secrets:SVC-0d805b77fe06",
-    "taskcluster_image_notify": "imbstack/taskcluster-notify:SVC-ee1fc68f33ad",
-    "taskcluster_image_docs": "imbstack/taskcluster-docs:SVC-d1c3ac76934e",
+    "taskcluster_image_auth": "imbstack/taskcluster-auth:SVC-b2fdaa83da44",
+    "taskcluster_image_queue": "imbstack/taskcluster-queue:SVC-f77e2b48c06c",
+    "taskcluster_image_index": "imbstack/taskcluster-index:SVC-c16e3ef85661",
+    "taskcluster_image_purge-cache": "imbstack/taskcluster-purge-cache:SVC-43bfa4dc6f55",
+    "taskcluster_image_github": "imbstack/taskcluster-github:SVC-63a7d71c06f7",
+    "taskcluster_image_login": "imbstack/taskcluster-login:SVC-e1a2b9c89662",
+    "taskcluster_image_pulse": "imbstack/taskcluster-pulse:SVC-e7b801fa4c5d",
+    "taskcluster_image_hooks": "imbstack/taskcluster-hooks:SVC-fe4f8b7d6f1b",
+    "taskcluster_image_secrets": "imbstack/taskcluster-secrets:SVC-d24ab378f52b",
+    "taskcluster_image_notify": "imbstack/taskcluster-notify:SVC-809df308fe82",
+    "taskcluster_image_gce-provider": "imbstack/taskcluster-gce-provider:SVC-609ed5f9c520",
+    "taskcluster_image_events": "imbstack/taskcluster-events:SVC-80ee1da7f3a9",
+    "taskcluster_image_docs": "imbstack/taskcluster-docs:SVC-22ab841f6174",
     "taskcluster_image_tools": "imbstack/taskcluster-tools:SVC-73a4dff84a34",
-    "taskcluster_image_references": "imbstack/taskcluster-references:SVC-2b22050e225d"
+    "taskcluster_image_references": "imbstack/taskcluster-references:SVC-d570292a5893"
   }
 }


### PR DESCRIPTION
This adds support for a few things:

1. A "gce-provider" that will provision instances for us until generic-provisioner is ready.
2. taskcluster-events
3. Support for mounting secret files as volumes in deployments/cron-jobs