### PR TITLE
Remove queue:create-task:* from tc-github's scopes

### DIFF
--- a/auth-service.tf
+++ b/auth-service.tf
@@ -97,7 +97,6 @@ locals {
       scopes = [
         "assume:repo:github.com/*",
         "assume:scheduler-id:taskcluster-github/*",
-        "queue:create-task:*",
         "auth:azure-table-access:${azurerm_storage_account.base.name}/TaskclusterGithubBuilds",
         "auth:azure-table-access:${azurerm_storage_account.base.name}/TaskclusterIntegrationOwners",
         "auth:azure-table:read-write:${azurerm_storage_account.base.name}/TaskclusterGithubBuilds",


### PR DESCRIPTION
create-task scopes should come from `repo:github.com:..` roles, not from
the client's own scopes. /cc @owlishDeveloper 